### PR TITLE
Upgrade to @gratheon/log-lib v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/composition": "2.1.3",
         "@apollo/gateway": "2.1.3",
+        "@gratheon/log-lib": "^3.0.0",
         "@sentry/node": "7.57.0",
         "apollo-server": "3.10.1",
         "apollo-server-express": "3.13.0",
@@ -512,6 +513,16 @@
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@gratheon/log-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@gratheon/log-lib/-/log-lib-3.0.0.tgz",
+      "integrity": "sha512-Kxfwo8vk1gefopfqla6nzuOfwRi1CKaqOFLlgIZ3OeEYmrckTdGlXaY8D95+RdtjToYAkfG54bX3CeQukbIXgw==",
+      "license": "ISC",
+      "dependencies": {
+        "fast-safe-stringify": "^2.1.1",
+        "source-map-support": "^0.5.21"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -1674,7 +1685,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -2358,6 +2368,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -4753,7 +4769,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4763,7 +4778,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@apollo/composition": "2.1.3",
     "@apollo/gateway": "2.1.3",
+    "@gratheon/log-lib": "^3.0.0",
     "@sentry/node": "7.57.0",
     "apollo-server": "3.10.1",
     "apollo-server-express": "3.13.0",

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,62 +1,15 @@
-function log(level: string, message: string, meta?: any) {
-    let time = new Date().toISOString();
-    let hhMMTime = time.slice(11, 19);
-    meta = meta ? JSON.stringify(meta) : '';
+import { createLogger } from "@gratheon/log-lib";
 
-    // colorize time to have ansi blue color
-    hhMMTime = `\x1b[34m${hhMMTime}\x1b[0m`;
-
-    if (level === 'error') {
-        level = `\x1b[31m${level}\x1b[0m`;
-        meta = `\x1b[35m${meta}\x1b[0m`;
-    } else if (level === 'info') {
-        level = `\x1b[32m${level}\x1b[0m`;
-        meta = `\x1b[35m${meta}\x1b[0m`;
-    } else if (level === 'debug') {
-        level = `\x1b[90m${level}\x1b[0m`;
-        message = `\x1b[90m${message}\x1b[0m`;
-        meta = `\x1b[90m${meta}\x1b[0m`;
-    } else if (level === 'warn') {
-        level = `\x1b[33m${level}\x1b[0m`;
-        meta = `\x1b[35m${meta}\x1b[0m`;
-    }
-
-    console.log(`${hhMMTime} [${level}]: ${message} ${meta}`);
-}
+const { logger: baseLogger } = createLogger();
 
 export const logger = {
-    log: (message: string, meta?: any) => {
-        log('info', message, meta)
-    },
-    info: (message: string, meta?: any) => {
-        log('info', message, meta)
-    },
-    error: (message: string | Error | any, meta?: any) => {
-        if (message.message && message.stack) {
-            return log('error', message.message, {
-                stack: message.stack,
-                ...meta
-            });
-        }
-        log('error', String(message), meta)
-    },
-    errorEnriched: (message: string, error: Error|any, meta?: any) => {
-        if (error.message && error.stack) {
-            return log('error', `${message}: ${error.message}`, {
-                stack: error.stack,
-                ...meta
-            });
-        }
-        log('error', String(message), meta)
-    },
-    warn: (message: string, meta?: any) => {
-        log('warn', message, meta)
-    },
-
-    // do not store debug logs in DB
-    debug: (message: string, meta?: any) => {
-        log('debug', message, meta)
-    },
+    log: (message: string, meta?: any) => baseLogger.info(message, meta as any),
+    info: (message: string, meta?: any) => baseLogger.info(message, meta as any),
+    warn: (message: string, meta?: any) => baseLogger.warn(message, meta as any),
+    debug: (message: string, meta?: any) => baseLogger.debug(message, meta as any),
+    error: (message: string | Error | any, meta?: any) => baseLogger.error(message, meta as any),
+    errorEnriched: (message: string, error: Error | any, meta?: any) =>
+        baseLogger.errorEnriched(message, error, meta as any),
 };
 
 


### PR DESCRIPTION
## Summary
- add and bump @gratheon/log-lib to ^3.0.0
- replace local logger implementation with a log-lib-backed wrapper
- preserve existing logger call signatures for compatibility

## Validation
- npm build passes
